### PR TITLE
Make parse_requirements compatible with newer pip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build
 .coverage
 *.egg-info/
 venv*
+.tox/

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,12 @@
 import os
 import sys
 import pip
-from pip.req import parse_requirements
+
+try: # for pip >= 10
+    from pip._internal.req import parse_requirements
+except ImportError: # for pip <= 9.0.3
+    from pip.req import parse_requirements
+
 from setuptools import setup
 
 import wpparser

--- a/setup.py
+++ b/setup.py
@@ -3,34 +3,14 @@
 
 import os
 import sys
-import pip
 
-try: # for pip >= 10
-    from pip._internal.req import parse_requirements
-except ImportError: # for pip <= 9.0.3
-    from pip.req import parse_requirements
-
-from setuptools import setup
+from setuptools import find_packages, setup
 
 import wpparser
 
 if sys.argv[-1] == "publish":
     os.system("python setup.py sdist upload")
     sys.exit()
-
-
-packages = [
-    "wpparser"
-]
-
-# Handle requirements
-requires = parse_requirements("requirements/install.txt",
-                              session=pip.download.PipSession())
-install_requires = [str(ir.req) for ir in requires]
-
-requires = parse_requirements("requirements/tests.txt",
-                              session=pip.download.PipSession())
-tests_require = [str(ir.req) for ir in requires]
 
 # Convert markdown to rst
 try:
@@ -47,11 +27,13 @@ setup(
     author="Martin Sandström",
     author_email="martin@marteinn.se",
     url="https://github.com/marteinn/wpparser",
-    packages=packages,
+    packages=find_packages(),
     package_data={"": ["LICENSE", ], "wpparser": ["*.txt"]},
     package_dir={"wpparser": "wpparser"},
     include_package_data=True,
-    install_requires=install_requires,
+    install_requires=[
+        "phpserialize>=1.3"
+    ],
     license="MIT",
     zip_safe=False,
     classifiers=(
@@ -61,8 +43,9 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python",
         "Programming Language :: Python :: 2.7"
-        "Programming Language :: Python :: 3.2",
-        "Programming Language :: Python :: 3.3",
-        "Programming Language :: Python :: 3.4"
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8"
     ),
+    python_requires=">=2.7",
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+envlist=py27,py36,py37,py38
+
+[testenv]
+deps=
+    pytest
+    phpserialize>=1.3
+commands=
+    pytest -s runtests.py


### PR DESCRIPTION
On newer versions on of pip, install is failing with ```ModuleNotFoundError: No module named 'pip.req'```. This fixes that issue.